### PR TITLE
Fixed save bug and rf definition

### DIFF
--- a/NOW_GUI.m
+++ b/NOW_GUI.m
@@ -614,7 +614,7 @@ fprintf(outfile_whole, '%8.0i\r\n', size(out_mat_whole, 2));
 fprintf(outfile_whole, formatspec, out_mat_whole);
 fclose (outfile_whole);
 
-z_ind = result.optimizerProblem.zeroGradientAtIndex;
+z_ind = result.zind;
 
 % If the waveform is split into two parts, it is also stored as two
 % individual files with endings "_A" and "_B".

--- a/private/optimize.m
+++ b/private/optimize.m
@@ -101,9 +101,10 @@ else
     rf = ones(size(problem.signs));
 end
 
-result.rf = [0; rf; 0];                         % Spin direction
-result.gwf = bsxfun(@times, result.rf, g/1000); % T/m
-result.dt  = problem.dt/1000;                   % s
+result.zind = problem.zeroGradientAtIndex;       % Keep this info for save function
+result.rf   = [rf(1); rf; rf(end)];              % Spin direction
+result.gwf  = bsxfun(@times, result.rf, g/1000); % T/m
+result.dt   = problem.dt/1000;                   % s
 
 end
 


### PR DESCRIPTION
Save was broken when calculating part A and B due to missing optimization problem. Saved the zero index in the result.

Change definition of the spin direction (rf) to fit with mddmri framework.